### PR TITLE
fix: updates goreleaser to re-enable the release step

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,9 +30,6 @@ changelog:
       - "^docs:"
       - "^test:"
 
-release:
-  disable: true
-
 brews:
   - tap:
       owner: masterpointio


### PR DESCRIPTION
## Info

Re-enables goreleaser's release functionality as it seems that is required. 