### PR TITLE
fix: pin GitHub Actions to commit SHAs (INT-326)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,4 +26,4 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:
-          args: release --snapshot --skip-publish --rm-dist
+          args: release --snapshot --skip=publish --rm-dist

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,4 +26,4 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:
-          args: release --snapshot --skip=publish --rm-dist
+          args: release --snapshot --skip=publish --clean

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: Build & Test
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "^1.14.0"
       - run: go mod download
@@ -24,6 +24,6 @@ jobs:
           go build -v .
           go test ./...
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@master
+        uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:
           args: release --snapshot --skip-publish --rm-dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,14 +8,14 @@ jobs:
     runs-on: ubuntu-latest
     name: goreleaser
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Unshallow Fetch
         run: git fetch --prune --unshallow
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "^1.14.0"
       - name: Release via goreleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:
           distribution: goreleaser
           version: latest

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 before:
   hooks:
     # You may remove this if you don't use go modules.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,7 @@ builds:
       - darwin
       - windows
 archives:
-  - name_template: "{{ replace .Binary \"_\" \"-\" }}_{{ .Version }}_{{ title .Os }}_{{- if eq .Arch \"amd64\" }}x86_64{{- else }}{{ .Arch }}{{ end }}{{- if .Arm }}v{{ .Arm }}{{ end }}"
+  - - name_template: "{{ replace .Binary \"_\" \"-\" }}_{{ .Version }}_{{- if eq .Os \"darwin\" }}Darwin{{- else if eq .Os \"windows\" }}Windows{{- else }}Linux{{ end }}_{{- if eq .Arch \"amd64\" }}x86_64{{- else if eq .Arch \"386\" }}i386{{- else }}{{ .Arch }}{{ end }}{{- if .Arm }}v{{ .Arm }}{{ end }}"
 checksum:
   name_template: "checksums.txt"
 snapshot:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,18 +13,18 @@ builds:
       - darwin
       - windows
 archives:
-  - name_template: "{{ .ProjectName }}_{{- if eq .Os \"darwin\" }}Darwin{{- else if eq .Os \"windows\" }}Windows{{- else }}Linux{{ end }}_{{- if eq .Arch \"amd64\" }}x86_64{{- else if eq .Arch \"386\" }}i386{{- else }}{{ .Arch }}{{ end }}" 
+  - name_template: "{{ .ProjectName }}_{{- if eq .Os \"darwin\" }}Darwin{{- else if eq .Os \"windows\" }}Windows{{- else }}Linux{{ end }}_{{- if eq .Arch \"amd64\" }}x86_64{{- else if eq .Arch \"386\" }}i386{{- else }}{{ .Arch }}{{ end }}"
 checksum:
   name_template: "checksums.txt"
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"
 changelog:
   sort: asc
   filters:
     exclude:
       - "^docs:"
       - "^test:"
-brews:
+homebrew_casks:
   - repository:
       owner: masterpointio
       name: homebrew-tap

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,7 +17,7 @@ archives:
 checksum:
   name_template: "checksums.txt"
 snapshot:
-  version_template: "{{ .Tag }}-next"
+  version_template: "{{ .Version }}-next"
 changelog:
   sort: asc
   filters:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,4 @@
 version: 2
-
 before:
   hooks:
     # You may remove this if you don't use go modules.
@@ -14,13 +13,7 @@ builds:
       - darwin
       - windows
 archives:
-  - name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+  - name_template: "{{ replace .Binary \"_\" \"-\" }}_{{ .Version }}_{{ title .Os }}_{{- if eq .Arch \"amd64\" }}x86_64{{- else }}{{ .Arch }}{{ end }}{{- if .Arm }}v{{ .Arm }}{{ end }}"
 checksum:
   name_template: "checksums.txt"
 snapshot:
@@ -31,9 +24,8 @@ changelog:
     exclude:
       - "^docs:"
       - "^test:"
-
 brews:
-  - tap:
+  - repository:
       owner: masterpointio
       name: homebrew-tap
     description: Easily run one-off tasks against an ECS Task Definition.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,5 +30,3 @@ homebrew_casks:
       name: homebrew-tap
     description: Easily run one-off tasks against an ECS Task Definition.
     homepage: https://github.com/masterpointio/ecsrun
-    test: |
-      system "#{bin}/ecsrun --version"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,7 @@ builds:
       - darwin
       - windows
 archives:
-  - name_template: "{{ replace .Binary \"_\" \"-\" }}_{{ .Version }}_{{- if eq .Os \"darwin\" }}Darwin{{- else if eq .Os \"windows\" }}Windows{{- else }}Linux{{ end }}_{{- if eq .Arch \"amd64\" }}x86_64{{- else if eq .Arch \"386\" }}i386{{- else }}{{ .Arch }}{{ end }}{{- if .Arm }}v{{ .Arm }}{{ end }}"
+  - name_template: "{{ .ProjectName }}_{{- if eq .Os \"darwin\" }}Darwin{{- else if eq .Os \"windows\" }}Windows{{- else }}Linux{{ end }}_{{- if eq .Arch \"amd64\" }}x86_64{{- else if eq .Arch \"386\" }}i386{{- else }}{{ .Arch }}{{ end }}" 
 checksum:
   name_template: "checksums.txt"
 snapshot:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,7 @@ builds:
       - darwin
       - windows
 archives:
-  - - name_template: "{{ replace .Binary \"_\" \"-\" }}_{{ .Version }}_{{- if eq .Os \"darwin\" }}Darwin{{- else if eq .Os \"windows\" }}Windows{{- else }}Linux{{ end }}_{{- if eq .Arch \"amd64\" }}x86_64{{- else if eq .Arch \"386\" }}i386{{- else }}{{ .Arch }}{{ end }}{{- if .Arm }}v{{ .Arm }}{{ end }}"
+  - name_template: "{{ replace .Binary \"_\" \"-\" }}_{{ .Version }}_{{- if eq .Os \"darwin\" }}Darwin{{- else if eq .Os \"windows\" }}Windows{{- else }}Linux{{ end }}_{{- if eq .Arch \"amd64\" }}x86_64{{- else if eq .Arch \"386\" }}i386{{- else }}{{ .Arch }}{{ end }}{{- if .Arm }}v{{ .Arm }}{{ end }}"
 checksum:
   name_template: "checksums.txt"
 snapshot:


### PR DESCRIPTION

## Info

- Pins all `uses:` references in GitHub Actions workflows to full commit SHAs.
- Updates goreleaser to current version, fixes deprecations and changes of tool use

## References

- https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned CI and release actions to fixed revisions to stabilize workflows.
  * Updated release tooling configuration for consistent archive naming and Homebrew packaging metadata.
  * Adjusted release command options to align with the updated release tooling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->